### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,5 +1,6 @@
 class PurchasesController < ApplicationController
   before_action :authenticate_user!, only: [:index]
   def index
+    
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,6 +1,5 @@
 class PurchasesController < ApplicationController
   before_action :authenticate_user!, only: [:index]
   def index
-    
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,4 +1,5 @@
 class PurchasesController < ApplicationController
+  before_action :authenticate_user!, only: [:index]
   def index
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,12 +123,12 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', '#' , class: "subtitle" %>
     <ul class='item-lists'>
 
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,21 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
+      <% if @item.purchase %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price%>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -36,33 +38,33 @@
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,10 +26,14 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <% if current_user.id == @item.user%>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+
+    <% end %>
+    
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -94,11 +94,11 @@
     </form>
   </div>
   <div class="links">
-    <%= link_to '＜ 前の商品', "#" class: "change-item-btn" %>
-    <%= link_to '＞ 後ろの商品', "#" class: "change-item-btn" %>
+    <%= link_to '＜ 前の商品', "#", class: "change-item-btn" %>
+    <%= link_to '＞ 後ろの商品', "#", class: "change-item-btn" %>
 
   </div>
-  <%= link_to 'その他をもっと見る', "#" class: "another-item" %>
+  <%= link_to 'その他をもっと見る', "#", class: "another-item" %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-    <% if current_user.id == @item.user%>
+    <% if current_user == @item.user %>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
@@ -36,8 +36,8 @@
 
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if current_user.id != @item.user%>
-    <%= link_to '購入画面に進む',  ,class:"item-red-btn"%>
+    <% if current_user != @item.user%>
+    <%= link_to '購入画面に進む', item_purchases_path(@item.id) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,11 +33,13 @@
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
     <% end %>
-    
+
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if current_user.id != @item.user%>
+    <%= link_to '購入画面に進む',  ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
 

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -13,7 +13,7 @@
           <%= "商品説明" %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= 999,999,999 %></p>
+          <%# <p class='item-price-text'>¥<%= 999,999,999 %></p> 
           <p class='item-price-sub-text'>（税込）送料込み</p>
         </div>
       </div>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -13,7 +13,7 @@
           <%= "商品説明" %>
         </h2>
         <div class='buy-item-price'>
-          <%# <p class='item-price-text'>¥<%= 999,999,999 %></p> 
+          <p class='item-price-text'>¥<%=  %></p> 
           <p class='item-price-sub-text'>（税込）送料込み</p>
         </div>
       </div>


### PR DESCRIPTION
##WHAT
1.詳細ページに登録情報の表示

2.編集削除リンクは出品者のみに表示

3.出品者以外に購入画面の表示

4.非ログインユーザーの場合購入画面へ行く際ログイン
画面への遷移

##WHY
1.showアクションでurlパラメータから送られてくるidを取得して@itemに代入して表示した。

2.条件分岐してログインユーザーのidと@itemレコードに入っているuser_idが一致した場合のみ表示するようにした。

3.条件分岐の際に論理演算子(!=)を使用してログインユーザーと@itemが持っているuser_idが一致しない場合のみ表示するようにした。

4.非ログインユーザーの場合ログイン画面へ遷移するように遷移先のpurchasesコントローラーindexアクションに対してbefore_actionでauthenticate_user!を設定した。

https://gyazo.com/c856dd0c89ac73ee7b2e578e0d3ce0dd